### PR TITLE
Fixed typo in comment

### DIFF
--- a/random-splash-image.el
+++ b/random-splash-image.el
@@ -5,7 +5,7 @@
 ;; Author: kakakaya <kakakaya AT gmail.com>
 ;; Keywords: games
 ;; Version: 1.0.0
-;; URL: https://github.com/kakakaya/random-splah-image
+;; URL: https://github.com/kakakaya/random-splash-image
 
 ;; Licence:
 ;; The MIT License (MIT)


### PR DESCRIPTION
This typo was also carried over to in the melpa package description.
